### PR TITLE
fix: remove unsafe-inline from CSP script-src

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://openrouter.ai https://*.posthog.com https://skillregistry.io"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://openrouter.ai https://*.posthog.com https://skillregistry.io"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- Remove `'unsafe-inline'` from `script-src` in Content Security Policy (CSP-001, High)
- Keeps `'unsafe-inline'` in `style-src` (required for Tailwind CSS)

## Findings Addressed
CSP-001 (1 finding)

## Test plan
- [ ] Verify app loads and renders correctly without inline scripts
- [ ] Verify CSP header blocks inline script injection attempts