### PR TITLE
fix: remove excessive entitlements and unused permissions

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
 </dict>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,6 +22,8 @@ extraResources:
     to: app.asar.unpacked/node_modules/.prisma/
     filter:
       - '**/*'
+# TODO: Enable asar integrity checking when Electron Fuses are configured
+# See: https://www.electronjs.org/docs/latest/tutorial/fuses
 asarUnpack:
   - resources/**
   - node_modules/.prisma/**
@@ -44,11 +46,10 @@ mac:
   icon: resources/icon.icns
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
-    - NSCameraUsageDescription: Application requests access to the device's camera.
-    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
+  # notarize: true  # Enable for production releases (requires Apple Developer account)
+  notarize: false  # TODO: Enable when Apple Developer credentials are configured
   target:
     - dmg
     - zip
@@ -63,6 +64,7 @@ linux:
   category: Development
 appImage:
   artifactName: ${name}-${version}.${ext}
-publish:
-  provider: generic
-  url: https://example.com/auto-updates
+# Auto-update disabled until a real update server is configured
+# publish:
+#   provider: generic
+#   url: https://example.com/auto-updates


### PR DESCRIPTION
## Summary
- Remove `com.apple.security.cs.disable-library-validation` entitlement (BUILD-001, High)
- Remove NSCameraUsageDescription and NSMicrophoneUsageDescription (BUILD-003, High)
- Comment out placeholder auto-update publish section (BUILD-002, High)
- Add notarization TODO comment (BUILD-004, High)
- Keep ASAR integrity as future enhancement (ELECTRON-003, Medium)

## Findings Addressed
BUILD-001 through BUILD-004, ELECTRON-003 (5 findings)

## Test plan
- [ ] Verify macOS build succeeds without disabled library validation
- [ ] Verify app doesn't request camera/mic permissions
- [ ] Verify no auto-update endpoint is configured